### PR TITLE
hg2git: fix splitting logic in two methods

### DIFF
--- a/bitbucket_hg_exporter/hg2git.py
+++ b/bitbucket_hg_exporter/hg2git.py
@@ -609,9 +609,10 @@ def get_git_log(repo_path):
         errors="replace",
     )
     data, _ = p.communicate()
+    splittable_data = '\n' + data
 
     output = []
-    for i, d in enumerate(data.split("\n" + uuid_node_delim)):
+    for i, d in enumerate(splittable_data.split("\n" + uuid_node_delim)):
         if not d:
             continue
         message = {}
@@ -647,9 +648,10 @@ def get_hg_hashes_from_git(repo_path):
         errors="replace",
     )
     data, _ = p.communicate()
+    splittable_data = '\n' + data
 
     output = {}
-    for i, d in enumerate(data.split("\n" + uuid_node_delim)):
+    for i, d in enumerate(splittable_data.split("\n" + uuid_node_delim)):
         if not d:
             continue
         message = {}


### PR DESCRIPTION
`get_git_log` and `get_hg_hashes_from_git` both use random UUID's as delimiters
in formatted git log output and split the data on a newline followed by
the specific UUID.
This fails for the first line in the formatted log.
As a quick workaround, I've prepended a newline to the log data so it
should split correctly.