### PR TITLE
Show unmerged pull requests diffs

### DIFF
--- a/bitbucket_hg_exporter/gh-pages-template/ng/pullrequest-details/pullrequest-details.component.js
+++ b/bitbucket_hg_exporter/gh-pages-template/ng/pullrequest-details/pullrequest-details.component.js
@@ -23,7 +23,7 @@ angular.
               var p1 = $http.get(self.pr['destination']['commit']['links']['self']['href']).then(function(response) {
                 self.dest_commit = response.data;
               });
-              var p2 = $http.get(self.pr['merge_commit']['links']['self']['href']).then(function(response) {
+              var p2 = $http.get(self.pr['source']['commit']['links']['self']['href']).then(function(response) {
                 self.merge_commit = response.data;
               });
               Promise.all([p1, p2]).then(function(){

--- a/bitbucket_hg_exporter/gh-pages-template/ng/pullrequest-details/pullrequest-details.template.html
+++ b/bitbucket_hg_exporter/gh-pages-template/ng/pullrequest-details/pullrequest-details.template.html
@@ -28,7 +28,7 @@
                   <tr>
                     <td>Updated on: <span uib-tooltip="{{$ctrl.pr.updated_on | date: 'dd MMMM yyyy HH:mm'}}" tooltip-placement="right">{{$ctrl.pr.updated_on | date: 'yyyy-MM-dd'}}</span></td>
                   </tr>
-                  <tr ng-if="$ctrl.diff_url && $ctrl.pr.state=='MERGED'">
+                  <tr ng-if="$ctrl.diff_url">
                     <td><a ng-href="{{$ctrl.diff_url}}">View diff on GitHub</a></td>
                   </tr>
                 </table>

--- a/bitbucket_hg_exporter/gh-pages-template/ng/pullrequest-details/pullrequest-details.template.html
+++ b/bitbucket_hg_exporter/gh-pages-template/ng/pullrequest-details/pullrequest-details.template.html
@@ -28,7 +28,7 @@
                   <tr>
                     <td>Updated on: <span uib-tooltip="{{$ctrl.pr.updated_on | date: 'dd MMMM yyyy HH:mm'}}" tooltip-placement="right">{{$ctrl.pr.updated_on | date: 'yyyy-MM-dd'}}</span></td>
                   </tr>
-                  <tr ng-if="$ctrl.diff_url">
+                  <tr ng-if="$ctrl.diff_url && $ctrl.pr.source.repository.full_name == $ctrl.pr.destination.repository.full_name">
                     <td><a ng-href="{{$ctrl.diff_url}}">View diff on GitHub</a></td>
                   </tr>
                 </table>


### PR DESCRIPTION
Currently the pull request diff URL's compare the `merge_commit` to the destination commit. I noticed that only `MERGED` pull requests are provided diff URL's, but I'd like to see these diff URL's also for open or declined pull request at the time of the export. This PR uses the source commit instead of the `merge_commit` for comparison and removes the `MERGED` restriction on display of diff URL's.

I've tested this change here:

* https://github.com/scpeters-test/gh-pages_srsim_github_auto_import/commit/0f908dd162f269672f4587bf9bf49809fb98d5f6
* https://scpeters-test.github.io/gh-pages_srsim_github_auto_import/#!/osrf/srsim/pull-requests/1/page/1