### PR TITLE
hg2git: encode git logs as ascii for consistency

### DIFF
--- a/bitbucket_hg_exporter/hg2git.py
+++ b/bitbucket_hg_exporter/hg2git.py
@@ -620,7 +620,7 @@ def get_git_log(repo_path):
             uuid_item_delim
         )
         message["revnum"] = message["node"]
-        message["desc"] = message["desc"].rstrip("\n")
+        message["desc"] = message["desc"].rstrip("\n").encode('ascii', 'replace').decode()
         output.append(message)
 
     return output


### PR DESCRIPTION
In 310e36e29d401, the hg log output is encoded as ascii to match the output
of Github's source import tool. This can cause a mismatch when using a
different source conversion tool that doesn't encode git logs to ascii.
For consistency, the hg2git modules encode both hg and git logs as ascii
before comparing them for matches.