### PR TITLE
Sort list of projects to load

### DIFF
--- a/bitbucket_hg_exporter/__main__.py
+++ b/bitbucket_hg_exporter/__main__.py
@@ -288,7 +288,7 @@ class MigrationProject(object):
             if not first_run or location == os.getcwd():
                 location = q.text("Where is the project folder located?", default=location).ask()
             if not first_run or project is None:
-                project_name = q.select("Select a project to load?", choices=os.listdir(location)).ask()
+                project_name = q.select("Select a project to load?", choices=sorted(os.listdir(location))).ask()
             elif first_run and project is not None:
                 project_name = project
 


### PR DESCRIPTION
When prompted to "Select a project to load?", the user is presented
with a list of project names in an arbitrary order. It is much
easier to visually parse if the list is alphabetized, so this sorts
this list prior to prompting for selection.