### PR TITLE
Catch KeyringLocked from keyring.get_password

### DIFF
--- a/bitbucket_hg_exporter/__main__.py
+++ b/bitbucket_hg_exporter/__main__.py
@@ -1662,7 +1662,10 @@ class MigrationProject(object):
     def __get_password(self, service, username, silent=True, force_new_password=False):
         if not force_new_password:
             # TODO: Look for saved passwords from other applications? (e.g. TortoiseHg)
-            password = self.__auth_credentials[service].get(username, None) or keyring.get_password(KEYRING_SERVICES[service], username)
+            try:
+                password = self.__auth_credentials[service].get(username, None) or keyring.get_password(KEYRING_SERVICES[service], username)
+            except keyring.errors.KeyringLocked:
+                password = None
             
             if password is not None:
                 # check the password works


### PR DESCRIPTION
When running the script on a remote Linux machine via ssh
that has gnome-keyring, a KeyringLocked exception may cause
a failure. Catching that exception can prevent the failure.