### PR TITLE
Ignore refs/branches to reduce export size / time

### DIFF
--- a/bitbucket_hg_exporter/__main__.py
+++ b/bitbucket_hg_exporter/__main__.py
@@ -1818,6 +1818,7 @@ class BitBucketExport(object):
             {'type': 'startswith', 'not':False, 'string':'repositories/{owner}/{repo}/issues/import'.format(owner=self.__owner, repo=self.__repository)},
             {'type': 'startswith', 'not':False, 'string':'repositories/{owner}/{repo}/issues/export'.format(owner=self.__owner, repo=self.__repository)},
             {'type': 'startswith', 'not':False, 'string':'repositories/{owner}/{repo}/hooks'.format(owner=self.__owner, repo=self.__repository)},
+            {'type': 'startswith', 'not':False, 'string':'repositories/{owner}/{repo}/refs/branches'.format(owner=self.__owner, repo=self.__repository)},
             # Get the list of commits, but not individual commit JSON files
             # {'type': 'endswith', 'not':True, 'string':'repositories/{owner}/{repo}/commits/'.format(owner=self.__owner, repo=self.__repository)},
             {'type': 'endswith', 'not':False, 'string':'/approve'},


### PR DESCRIPTION
I have exported some very large repositories and noticed
that the bitbucket_data_raw/repositories/*/*/commits folder
is by far the largest. Upon inspection, it appeared to be
dominated by multi-page json files for each branch.
This change adds an ignore rule for refs/branches URL's,
which substantially reduces the size of the commits folder
and the time it takes to export.
As a side-effect, it also excludes the refs/branches*.json
files and refs/branches/ folder, but that is not currently used
by the github-pages and seems like a worthwhile trade-off.

I'll provide a link to an example once I finish uploading it.