### PR TITLE
Skip deleted forks (404), rather than failing

### DIFF
--- a/bitbucket_hg_exporter/__main__.py
+++ b/bitbucket_hg_exporter/__main__.py
@@ -420,6 +420,12 @@ class MigrationProject(object):
                         else:
                             more = False
                     else:
+                        if status == 404:
+                            # some forks might have been deleted, but they are still reported by Bitbucket API
+                            # report the error and keep enumerating forks (of the remaining repos)
+                            print('Warning: repository {} might have been deleted (404).'.format(repository['full_name']))
+                            more = False
+                            continue
                         print('Failed to query BitBucket API when determining forks for {}.'.format(repository['full_name']))
                         sys.exit(1)
             

--- a/bitbucket_hg_exporter/__main__.py
+++ b/bitbucket_hg_exporter/__main__.py
@@ -419,13 +419,12 @@ class MigrationProject(object):
                             status, json_response = bbapi_json(json_response['next'], auth, {'pagelen':100})
                         else:
                             more = False
+                    elif status == 404:
+                        # some forks might have been deleted, but they are still reported by Bitbucket API
+                        # report the error and keep enumerating forks (of the remaining repos)
+                        print('Warning: repository {} might have been deleted (404).'.format(repository['full_name']))
+                        more = False
                     else:
-                        if status == 404:
-                            # some forks might have been deleted, but they are still reported by Bitbucket API
-                            # report the error and keep enumerating forks (of the remaining repos)
-                            print('Warning: repository {} might have been deleted (404).'.format(repository['full_name']))
-                            more = False
-                            continue
                         print('Failed to query BitBucket API when determining forks for {}.'.format(repository['full_name']))
                         sys.exit(1)
             


### PR DESCRIPTION
While trying to export the repository at https://bitbucket.org/hudson/magic-lantern/ (which has well over 500 forks), the script failed with this message:
``Failed to query BitBucket API when determining forks for yyfrankyy/magic-lantern.``

Turns out, several other forks were deleted, but they are still reported by Bitbucket API (possibly because a pull request was made from these repositories, and they were deleted afterwards by their author). With this change, the script was able to successfully enumerate all of the forks that are still online, and is now downloading them.

As I could identify at least 60 deleted forks, this issue is likely present for other users as well.

After the change, the script output looks like this:
```
Finding all forks of yyfrankyy/magic-lantern
Warning: repository yyfrankyy/magic-lantern might have been deleted (404).
Finding all forks of dbaleckaitis/magic-lantern
...
```